### PR TITLE
Hotfix: return an empty match when a new region is found

### DIFF
--- a/src/utils/fetchLookupKey.ts
+++ b/src/utils/fetchLookupKey.ts
@@ -1612,7 +1612,14 @@ export const lookupKeys = ({
   Province_State: string
   Country_Region: string
 }) => {
-  return filter(rawCollection, { Province_State, Country_Region })[0]
+  return (
+    filter(rawCollection, { Province_State, Country_Region })[0] || {
+      Province_State: "",
+      Country_Region: "",
+      iso3: "",
+      Population: "0",
+    }
+  )
 }
 
 export const lookupKeyByISO = (iso3: string) => {


### PR DESCRIPTION
The site was breaking upon load because the matching function that links that country data set from the COVID dataset didn't have a default state when a match wasn't found.